### PR TITLE
Change project license to CC BY-NC 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,8 @@
-MIT License
+Creative Commons Attribution-NonCommercial 4.0 International
 
 Copyright (c) 2024 Bria Long
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+To view a copy of this license, visit:
+https://creativecommons.org/licenses/by-nc/4.0/


### PR DESCRIPTION
### Motivation
- Replace the existing permissive MIT license with the Creative Commons Attribution-NonCommercial 4.0 International license to restrict reuse to non-commercial uses.

### Description
- Updated the `LICENSE` file to state `Creative Commons Attribution-NonCommercial 4.0 International` and added the canonical URL `https://creativecommons.org/licenses/by-nc/4.0/` in place of the previous MIT text.

### Testing
- Verified the `LICENSE` file contents with `nl -ba LICENSE` and confirmed the new license text is present; there are no code changes so no further automated tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ed1278a083309ce82804c3938964)