### PR TITLE
Add CLIP word-level similarity utility for THINGS (script + README)

### DIFF
--- a/stimuli/0_get_CLIP_similarities/README.md
+++ b/stimuli/0_get_CLIP_similarities/README.md
@@ -1,0 +1,24 @@
+# CLIP word-level similarity for THINGS items
+
+This folder contains a utility script for **item selection**.
+
+`get_item_clip_similarities.py` computes **word-level similarity across the full THINGS dataset** by:
+
+1. Loading concept words from `data/item_metadata/things_concepts.tsv`.
+2. Encoding each word with a running `clip-as-service` server.
+3. Computing an item-by-item correlation matrix from those embeddings.
+4. Writing the output to `stimuli/0_get_CLIP_similarities/things_dataset_item_embeddings.csv`.
+
+## Run
+
+From the repository root:
+
+```bash
+python3 -m clip_server
+python3 stimuli/0_get_CLIP_similarities/get_item_clip_similarities.py
+```
+
+## Notes
+
+- This script computes pairwise similarity for **all THINGS words** (not just a small subset).
+- The generated matrix is used upstream to help choose semantically graded distractors/items.

--- a/stimuli/0_get_CLIP_similarities/get_item_clip_similarities.py
+++ b/stimuli/0_get_CLIP_similarities/get_item_clip_similarities.py
@@ -1,35 +1,43 @@
- 
-# 
-# followed instructions using https://github.com/jina-ai/clip-as-service/tree/main/server
+"""Compute word-level CLIP similarity across the THINGS dataset.
 
-# before starting, run
-# python3 -m clip_server
-# python3
+This script encodes each THINGS concept word using a running clip-as-service
+server and writes an item-by-item correlation matrix used for distractor/item
+selection.
+"""
+
+from pathlib import Path
 
 from clip_client import Client
-c = Client('grpc://0.0.0.0:51000')
-import pandas as pd
 import numpy as np
-# has category items
+import pandas as pd
 
 
-# from things
-items = pd.read_csv('things_concepts.tsv', sep='\t')
-all_items = list(items['Word'])
-all_items =  all_items
-
-# wow so fast
-item_embeddings = c.encode(all_items)
-embeddings_items = np.size(item_embeddings,0)
-embeddings_vector_length= np.size(item_embeddings,0)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THINGS_CONCEPTS_PATH = REPO_ROOT / "data" / "item_metadata" / "things_concepts.tsv"
+OUTPUT_PATH = Path(__file__).resolve().parent / "things_dataset_item_embeddings.csv"
 
 
-# get correlations and save
-item_correlations = np.corrcoef(item_embeddings)
-item_correlations_df = pd.DataFrame(item_correlations)
-item_correlations_df.columns = all_items
-item_correlations_df_transposed = item_correlations_df.transpose()
-item_correlations_df_transposed.columns = all_items
-item_correlations_df_transposed.to_csv('things_test_all_item_embeddings.csv')
+def main() -> None:
+    # Start server first, e.g. `python3 -m clip_server`.
+    client = Client("grpc://0.0.0.0:51000")
+
+    items = pd.read_csv(THINGS_CONCEPTS_PATH, sep="\t")
+    if "Word" not in items.columns:
+        raise ValueError(f"Expected a 'Word' column in {THINGS_CONCEPTS_PATH}")
+
+    all_items = items["Word"].dropna().astype(str).tolist()
+    item_embeddings = client.encode(all_items)
+
+    # Keep these for sanity/debugging when run interactively.
+    n_items = np.size(item_embeddings, 0)
+    embedding_dim = np.size(item_embeddings, 1)
+    print(f"Encoded {n_items} items with embedding dim {embedding_dim}.")
+
+    item_correlations = np.corrcoef(item_embeddings)
+    similarity_df = pd.DataFrame(item_correlations, index=all_items, columns=all_items)
+    similarity_df.to_csv(OUTPUT_PATH, index_label="Word")
+    print(f"Wrote similarity matrix to {OUTPUT_PATH}")
 
 
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a reproducible utility to compute word-level CLIP similarities across the full THINGS dataset to support item/distractor selection.

### Description

- Add `stimuli/0_get_CLIP_similarities/get_item_clip_similarities.py` which loads `data/item_metadata/things_concepts.tsv`, encodes each concept with a running `clip-as-service` server via `clip_client.Client`, computes an item-by-item correlation matrix, and writes the output CSV to `stimuli/0_get_CLIP_similarities/things_dataset_item_embeddings.csv`.
- Add `stimuli/0_get_CLIP_similarities/README.md` with usage notes and the required run command `python3 -m clip_server` followed by `python3 stimuli/0_get_CLIP_similarities/get_item_clip_similarities.py`.
- Add basic input validation to check for a `Word` column and include small runtime diagnostics printing the encoded item count and embedding dimensionality.
- Use repository-root-relative paths via `Path(__file__).resolve().parents[2]` for robust file resolution.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f86c733c83308c1b754e6984e05d)